### PR TITLE
XN-943: Create the HubSpot object association endpoint

### DIFF
--- a/hubspot/association.go
+++ b/hubspot/association.go
@@ -1,0 +1,47 @@
+package hubspot
+
+const AssocationContactToCompany = "contact_to_company"
+
+type (
+	//AssociationInput handles an association from one type of object to another
+	AssociationInput struct {
+		Inputs []AssociationObject `json:"inputs"`
+	}
+
+	//AssocationObject is the two objects to be associated
+	AssociationObject struct {
+		AssociationType string        `json:"type"`
+		From            AssociationID `json:"from"`
+		To              AssociationID `json:"to"`
+	}
+
+	//AssocationID is the objects's ID to be assocaiated
+	AssociationID struct {
+		ID string `json:"id"`
+	}
+
+	//AssociationResults are the results from a succesful call to the HubSpot Association API
+	AssociationResults struct {
+		Status      string              `json:"string"`
+		StartedAt   string              `json:"started_at"`
+		CompletedAt string              `json:"created_at"`
+		Results     []AssociationObject `json:"results"`
+	}
+)
+
+//NewSingleContactToCompanyAssocaiationInput can be used to connect a company to a contact
+func NewSingleContactToCompanyAssociationInput(contactID string, companyID string) *AssociationInput {
+	return &AssociationInput{
+		Inputs: []AssociationObject{
+			AssociationObject{
+				AssociationType: AssocationContactToCompany,
+				From: AssociationID{
+					ID: contactID,
+				},
+				To: AssociationID{
+					ID: companyID,
+				},
+			},
+		},
+	}
+}

--- a/hubspot/association.go
+++ b/hubspot/association.go
@@ -1,40 +1,41 @@
 package hubspot
 
-const AssocationContactToCompany = "contact_to_company"
+// AssociationContactToCompany is the value for the "AssociationType" when associating contact and companies
+const AssociationContactToCompany = "contact_to_company"
 
 type (
-	//AssociationInput handles an association from one type of object to another
+	// AssociationInput handles an association from one type of object to another
 	AssociationInput struct {
-		Inputs []AssociationObject `json:"inputs"`
+		Inputs []Association `json:"inputs"`
 	}
 
-	//AssocationObject is the two objects to be associated
-	AssociationObject struct {
+	// Association handles the two items to be associated
+	Association struct {
 		AssociationType string        `json:"type"`
 		From            AssociationID `json:"from"`
 		To              AssociationID `json:"to"`
 	}
 
-	//AssocationID is the objects's ID to be assocaiated
+	// AssociationID handles the IDs to be associated
 	AssociationID struct {
 		ID string `json:"id"`
 	}
 
-	//AssociationResults are the results from a succesful call to the HubSpot Association API
+	// AssociationResults handles the results from a successful call to the HubSpot Association API
 	AssociationResults struct {
-		Status      string              `json:"string"`
-		StartedAt   string              `json:"started_at"`
-		CompletedAt string              `json:"created_at"`
-		Results     []AssociationObject `json:"results"`
+		Status      string        `json:"string"`
+		StartedAt   string        `json:"started_at"`
+		CompletedAt string        `json:"created_at"`
+		Results     []Association `json:"results"`
 	}
 )
 
-//NewSingleContactToCompanyAssocaiationInput can be used to connect a company to a contact
+// NewSingleContactToCompanyAssociationInput can be used to connect a company to a contact
 func NewSingleContactToCompanyAssociationInput(contactID string, companyID string) *AssociationInput {
 	return &AssociationInput{
-		Inputs: []AssociationObject{
-			AssociationObject{
-				AssociationType: AssocationContactToCompany,
+		Inputs: []Association{
+			Association{
+				AssociationType: AssociationContactToCompany,
 				From: AssociationID{
 					ID: contactID,
 				},

--- a/hubspot/association.go
+++ b/hubspot/association.go
@@ -24,8 +24,8 @@ type (
 	// AssociationResults handles the results from a successful call to the HubSpot Association API
 	AssociationResults struct {
 		Status      string        `json:"string"`
-		StartedAt   string        `json:"started_at"`
-		CompletedAt string        `json:"created_at"`
+		StartedAt   string        `json:"startedAt"`
+		CompletedAt string        `json:"completedAt"`
 		Results     []Association `json:"results"`
 	}
 )

--- a/hubspot/client.go
+++ b/hubspot/client.go
@@ -90,7 +90,7 @@ func BuildAssociationURL(c *Client, from string, to string) (string, error) {
 	from = strings.TrimSpace(from)
 	to = strings.TrimSpace(to)
 	if len(from) == 0 || len(to) == 0 {
-		return "", fmt.Errorf("from and to arguments require a value")
+		return "", fmt.Errorf("BuildAssociationURL(): from and to arguments require a value")
 	}
 	return fmt.Sprintf("%s/crm/%s/associations/%s/%s/batch/create?hapikey=%s", c.APIBaseURL, c.APIVersion, from, to, c.APIKey), nil
 }
@@ -125,7 +125,7 @@ func (c *Client) CreateAssociation(association *AssociationInput, from string, t
 
 		if err != nil {
 			errorResponse.Status = "error"
-			errorResponse.Message = fmt.Sprintf("Unable to unmarshal HubSpot association error response, err: %v", err)
+			errorResponse.Message = fmt.Sprintf("unable to unmarshal HubSpot association error response, err: %v", err)
 		}
 		return nil, errorResponse
 	}
@@ -162,7 +162,7 @@ func (c *Client) CreateContact(contactInput *ContactInput) (*ContactOutput, Erro
 
 		if err != nil {
 			errorResponse.Status = "error"
-			errorResponse.Message = fmt.Sprintf("Unable to unmarshal HubSpot create account error response, err: %v", err)
+			errorResponse.Message = fmt.Sprintf("unable to unmarshal HubSpot create account error response, err: %v", err)
 		}
 		return nil, errorResponse
 	}

--- a/hubspot/client.go
+++ b/hubspot/client.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -85,23 +85,35 @@ func (e ErrorResponse) Error() string {
 	return fmt.Sprintf(e.Message)
 }
 
-//CreateAssocation relates two objects to each other in HubSpot
-func (c *Client) CreateAssociation(association *AssociationInput, fromObject string, toObject string) (*AssociationResults, AssociationErrorResponse) {
-	log.Printf("INFO: attempting to create HubSpot object association")
+// BuildAssociationURL returns the URL for HubSpot object to object associations
+func BuildAssociationURL(c *Client, from string, to string) (string, error) {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	if len(from) == 0 || len(to) == 0 {
+		return "", fmt.Errorf("from and to arguments require a value")
+	}
+	return fmt.Sprintf("%s/crm/%s/associations/%s/%s/batch/create?hapikey=%s", c.APIBaseURL, c.APIVersion, from, to, c.APIKey), nil
+}
+
+// CreateAssociation relates two objects to each other in HubSpot
+func (c *Client) CreateAssociation(association *AssociationInput, from string, to string) (*AssociationResults, AssociationErrorResponse) {
 
 	requestBody, err := json.Marshal(association)
 	if err != nil {
-		log.Printf("ERROR: could not marshal the provided object association body, err: %v", err)
 		return nil, AssociationErrorResponse{Status: "error", Message: "invalid association input"}
 	}
 
+	requestURL, err := BuildAssociationURL(c, from, to)
+	if err != nil {
+		return nil, AssociationErrorResponse{Status: "error", Message: fmt.Sprintf("unable to build url, err: %v", err)}
+	}
+
 	r, err := c.request(
-		fmt.Sprintf("%s/crm/%s/associations/%s/%s/batch/create?hapikey=%s", c.APIBaseURL, c.APIVersion, fromObject, toObject, c.APIKey),
+		requestURL,
 		http.MethodPost,
 		requestBody)
 
 	if err != nil {
-		log.Printf("ERROR: unable to create HubSpot association")
 		return nil,
 			AssociationErrorResponse{Status: "error", Message: fmt.Sprintf("unable to execute request, err: %v", err)}
 	}
@@ -109,41 +121,28 @@ func (c *Client) CreateAssociation(association *AssociationInput, fromObject str
 	if r.StatusCode != http.StatusCreated {
 		var errorResponse AssociationErrorResponse
 		err := json.Unmarshal(r.Body, &errorResponse)
-		msg := "ERROR: unable to associate HubSpot objects. "
-		if err != nil {
-			log.Printf("%sUnable to unmarshall error response.", msg)
-		} else {
-			log.Printf("%sGot %d error(s):", msg, errorResponse.NumErrors)
-			// HubSpot returns an error for each potential problem with the association (ie, both ids are wrong results in two errors)
-			for i, itemError := range errorResponse.Errors {
-				log.Printf("error %d: %s", i+1, itemError.Message)
-			}
-		}
 		errorResponse.StatusCode = r.StatusCode
+
+		if err != nil {
+			errorResponse.Status = "error"
+			errorResponse.Message = fmt.Sprintf("Unable to unmarshal HubSpot association error response, err: %v", err)
+		}
 		return nil, errorResponse
 	}
 
 	var associationResult AssociationResults
 	if err := json.Unmarshal(r.Body, &associationResult); err != nil {
 		msg := fmt.Sprintf("could not unmarshal HubSpot response, err: %v", err)
-		log.Printf("ERROR: %s", msg)
 		return nil, AssociationErrorResponse{Status: "error", Message: msg}
 	}
-
-	log.Printf("INFO: HubSpot contact assocation created successfully. Contact ID: %s; Company ID %s",
-		association.Inputs[0].From.ID,
-		association.Inputs[0].To.ID)
 
 	return &associationResult, AssociationErrorResponse{}
 }
 
 // CreateContact creates a new Contact in HubSpot
 func (c *Client) CreateContact(contactInput *ContactInput) (*ContactOutput, ErrorResponse) {
-	log.Printf("INFO: attempting to create HubSpot Contact")
-
 	requestBody, err := json.Marshal(contactInput)
 	if err != nil {
-		log.Printf("ERROR: could not marshal the provided contact body, err: %v", err)
 		return nil, ErrorResponse{Status: "error", Message: "invalid contact input"}
 	}
 	r, err := c.request(
@@ -152,7 +151,6 @@ func (c *Client) CreateContact(contactInput *ContactInput) (*ContactOutput, Erro
 		requestBody)
 
 	if err != nil {
-		log.Printf("ERROR: unable to create HubSpot contact")
 		return nil,
 			ErrorResponse{Status: "error", Message: fmt.Sprintf("unable to execute request, err: %v", err)}
 	}
@@ -160,34 +158,28 @@ func (c *Client) CreateContact(contactInput *ContactInput) (*ContactOutput, Erro
 	if r.StatusCode != http.StatusCreated {
 		var errorResponse ErrorResponse
 		err := json.Unmarshal(r.Body, &errorResponse)
-		msg := "ERROR: unable to create HubSpot account. "
-		if err != nil {
-			log.Printf("%sUnable to unmarshall error response.", msg)
-		} else {
-			log.Printf("%sGot error: %v.", msg, errorResponse.Message)
-		}
 		errorResponse.StatusCode = r.StatusCode
+
+		if err != nil {
+			errorResponse.Status = "error"
+			errorResponse.Message = fmt.Sprintf("Unable to unmarshal HubSpot create account error response, err: %v", err)
+		}
 		return nil, errorResponse
 	}
 
 	var contactOutput ContactOutput
 	if err := json.Unmarshal(r.Body, &contactOutput); err != nil {
 		msg := fmt.Sprintf("could not unmarshal HubSpot response, err: %v", err)
-		log.Printf("ERROR: %s", msg)
 		return nil, ErrorResponse{Status: "error", Message: msg}
 	}
 
-	log.Printf("INFO: HubSpot contact created successfully. Contact ID: %s", contactOutput.ID)
 	return &contactOutput, ErrorResponse{}
 }
 
 // UpdateContact updates a Contact in HubSpot
 func (c *Client) UpdateContact(contactID string, contactInput *ContactInput) (*ContactOutput, ErrorResponse) {
-	log.Printf("INFO: attempting to update HubSpot Contact")
-
 	requestBody, err := json.Marshal(contactInput)
 	if err != nil {
-		log.Printf("ERROR: could not marshal the provided contact body, err: %v", err)
 		return nil, ErrorResponse{Status: "error", Message: "invalid contact input"}
 	}
 
@@ -195,7 +187,6 @@ func (c *Client) UpdateContact(contactID string, contactInput *ContactInput) (*C
 	r, err := c.request(apiURL, http.MethodPatch, requestBody)
 
 	if err != nil {
-		log.Printf("ERROR: unable to update HubSpot contact")
 		return nil,
 			ErrorResponse{Status: "error", Message: fmt.Sprintf("unable to execute request, err: %v", err)}
 	}
@@ -203,24 +194,21 @@ func (c *Client) UpdateContact(contactID string, contactInput *ContactInput) (*C
 	if r.StatusCode != http.StatusOK {
 		var errorResponse ErrorResponse
 		err := json.Unmarshal(r.Body, &errorResponse)
-		msg := "ERROR: unable to update HubSpot account:"
-		if err != nil {
-			log.Printf("%s unable to unmarshal error response.", msg)
-		} else {
-			log.Printf("%s got error: %v.", msg, errorResponse.Message)
-		}
 		errorResponse.StatusCode = r.StatusCode
+		if err != nil {
+			errorResponse.Status = "error"
+			errorResponse.Message = fmt.Sprintf("unable to unmarshal HubSpot update account error response, err: %v", err)
+		}
+
 		return nil, errorResponse
 	}
 
 	var contactOutput ContactOutput
 	if err := json.Unmarshal(r.Body, &contactOutput); err != nil {
 		msg := fmt.Sprintf("could not unmarshal HubSpot response, err: %v", err)
-		log.Printf("ERROR: %s", msg)
 		return nil, ErrorResponse{Status: "error", Message: msg}
 	}
 
-	log.Printf("INFO: HubSpot contact updated successfully. Contact ID: %s", contactOutput.ID)
 	return &contactOutput, ErrorResponse{}
 }
 
@@ -240,25 +228,20 @@ func (c *Client) request(
 
 	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(requestBody))
 	if err != nil {
-		log.Printf("ERROR: unable to create a HubSpot request, got error = %v", err)
 		return nil, errors.New("request execution failed")
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 	r, err := c.HTTPClient.Do(req)
 	if err != nil {
-		log.Printf("ERROR: unable to complete request, got error = %v", err)
 		return &response, errors.New("request execution failed")
 	}
 
 	defer r.Body.Close()
 
-	log.Printf("INFO: request successful, got response status: %v", r.StatusCode)
-
 	// prepare response
 	response.StatusCode = r.StatusCode
 	if err := json.NewDecoder(r.Body).Decode(&response.Body); err != nil {
-		log.Printf("ERROR: could not decode HubSpot response, err: %v", err)
 		return &response, errors.New("ERROR: could not decode response")
 	}
 

--- a/hubspot/hubspotiface/interface.go
+++ b/hubspot/hubspotiface/interface.go
@@ -6,6 +6,7 @@ import (
 
 // HubSpotClient is an interface for the Hubspot Client
 type HubSpotClient interface {
+	CreateAssociation(association *hubspot.AssociationInput, from string, to string) (*hubspot.AssociationResults, hubspot.AssociationErrorResponse)
 	CreateContact(contactInput *hubspot.ContactInput) (*hubspot.ContactOutput, hubspot.ErrorResponse)
 	UpdateContact(contactID string, contactInput *hubspot.ContactInput) (*hubspot.ContactOutput, hubspot.ErrorResponse)
 }


### PR DESCRIPTION
This enables to objects, such a a contact and a client, to be associated in HubSpot. The endpoint itself is generic and can be used for any associations.

For our uses, we will only be associating objects just one at a time, so the type helper function was created with that in mind

https://athletesperformance.atlassian.net/browse/XN-943

belie@administrators-MacBook-Pro-4 hubspot-api-go % make test
go test -timeout 30s github.com/teamexos/hubspot-api-go/hubspot
ok      github.com/teamexos/hubspot-api-go/hubspot      0.156s