### PR TITLE
XN-1259 create the ability to get a user from hubspot

### DIFF
--- a/hubspot/client_test.go
+++ b/hubspot/client_test.go
@@ -401,7 +401,7 @@ func TestAssociationURL(t *testing.T) {
 
 }
 func TestReadContact(t *testing.T) {
-	c := hubSpot.NewClient("99dd2540-40e4-4a59-a6cb-410924075261")
+	c := hubSpot.NewClient("fake-api-key")
 
 	fakeEmail := faker.Internet().Email()
 

--- a/hubspot/hubspotiface/interface.go
+++ b/hubspot/hubspotiface/interface.go
@@ -9,6 +9,7 @@ type HubSpotClient interface {
 	CreateAssociation(association *hubspot.AssociationInput, from string, to string) (*hubspot.AssociationResults, hubspot.AssociationErrorResponse)
 	CreateContact(contactInput *hubspot.ContactInput) (*hubspot.ContactOutput, hubspot.ErrorResponse)
 	UpdateContact(contactID string, contactInput *hubspot.ContactInput) (*hubspot.ContactOutput, hubspot.ErrorResponse)
+	ReadContact(email string, properties string) (*hubspot.ContactOutput, hubspot.ErrorResponse)
 }
 
 // make sure hubspot.Client type satisfies the HubSpotClient interface


### PR DESCRIPTION
XN-1259 Adds the ability to get a user in hubspot by their email address. This is need to determine whether to add or create a user in hubspot when someone is registering for Prince

https://athletesperformance.atlassian.net/browse/XN-1180